### PR TITLE
Support dynamic patterns when scanning for add-ons

### DIFF
--- a/StandaloneTestApp.cpp
+++ b/StandaloneTestApp.cpp
@@ -14,7 +14,7 @@ int main(int argc, char* argv[])
 
     const auto addons = [&] {
         unsigned int count;
-        auto* addons = GW2Load_GetAddonsInDirectory(argv[1], &count, true);
+        auto* addons = GW2Load_GetAddonsInDirectory(argv[1], &count, nullptr);
         return std::span{ addons, count };
     }();
 

--- a/api.h
+++ b/api.h
@@ -152,11 +152,11 @@ struct GW2Load_EnumeratedAddon
 {
     const char* path;
     const char* name;
+    const bool isEnabled;
 };
 
 extern "C"
 {
-    // If allowDisabled is true, addons ending in a .dll.disabled extension will also be returned
-    GW2LOAD_EXPORT GW2Load_EnumeratedAddon* GW2Load_GetAddonsInDirectory(const char* directory, unsigned int* count, bool allowDisabled);
+    GW2LOAD_EXPORT GW2Load_EnumeratedAddon* GW2Load_GetAddonsInDirectory(const char* directory, unsigned int* count, const char* pattern);
     GW2LOAD_EXPORT bool GW2Load_CheckIfAddon(const char* path);
 }


### PR DESCRIPTION
This has the advantage that the loader does not have to know what the manager does when disabling add-ons, so we effectively remove a dependency on external behavior here. There are probably things to improve but you get the general idea. Specifically, I wonder if we should extract the regex for enabled add-ons into a single place.