### PR TITLE
Explicitly set dbghelp options

### DIFF
--- a/Loader.cpp
+++ b/Loader.cpp
@@ -136,6 +136,8 @@ struct InspectionHandle
             return;
         }
 
+        SymSetOptions(SYMOPT_DEFERRED_LOADS);
+
         if (!SymInitialize(process, nullptr, false))
         {
             spdlog::critical("Could not initialize symbol handler: {}", GetLastErrorMessage());


### PR DESCRIPTION
Resets the dbghelp option mask to something that works for us before initializing the library.

This is crucial in processes where dbghelp might have been used before. For example, [the JVM uses dbghelp in Hotspot](https://github.com/openjdk/jdk/blob/910bb68e5191f830ff6f3dff5753e4e5f6214a7b/src/hotspot/os/windows/symbolengine.cpp#L493-L495). Specifically, `SYMOPT_EXACT_SYMBOLS` prevents us from loading exported symbols as required.

This has also sparked https://bugs.openjdk.org/browse/JDK-8333470 which I need to follow-up on. _This would have happened if I had ever gotten any notification besides the original filing confirmation._